### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/dispatcher.go
+++ b/dispatcher.go
@@ -68,7 +68,7 @@ type Dispatcher struct {
 	poolTcpIpv6            map[types.HashedTcpIpv6Flow]ConnectionInterface
 }
 
-// NewInquisitor creates a new Inquisitor struct
+// NewDispatcher creates a new Inquisitor struct
 func NewDispatcher(options DispatcherOptions, connectionFactory ConnectionFactory, packetLoggerFactory types.PacketLoggerFactory) *Dispatcher {
 	i := Dispatcher{
 		PacketLoggerFactory:   packetLoggerFactory,
@@ -102,7 +102,7 @@ func (i *Dispatcher) Stop() {
 	log.Printf("%d connection(s) closed.", closedConns)
 }
 
-// connectionsLocked returns a slice of Connection pointers.
+// Connections returns a slice of Connection pointers.
 func (i *Dispatcher) Connections() []ConnectionInterface {
 	return i.connections()
 }

--- a/types/flow.go
+++ b/types/flow.go
@@ -81,7 +81,7 @@ func (t *TcpIpFlow) Equal(s *TcpIpFlow) bool {
 	return t.ipFlow == s.ipFlow && t.tcpFlow == s.tcpFlow
 }
 
-// getPacketFlow returns a TcpIpFlow struct given a byte array packet
+// NewTcpIpFlowFromPacket returns a TcpIpFlow struct given a byte array packet
 func NewTcpIpFlowFromPacket(packet []byte) (*TcpIpFlow, error) {
 	var ip layers.IPv4
 	var tcp layers.TCP


### PR DESCRIPTION
Every exported function in a program should have a doc comment. The first sentence should be a summary that starts with the name being declared.
From [effective go](https://golang.org/doc/effective_go.html#commentary).

I generated this with [CodeLingo](https://codelingo.io) and I'm keen to get some feedback, _but this is automated so feel free to close it and just say "**opt out**" to opt out of future CodeLingo outreach PRs._